### PR TITLE
Add initial EXTENDED COPY support

### DIFF
--- a/pyscsi/pyscsi/scsi.py
+++ b/pyscsi/pyscsi/scsi.py
@@ -9,6 +9,8 @@
 from pyscsi.pyscsi.scsi_cdb_atapassthrough12 import ATAPassThrough12
 from pyscsi.pyscsi.scsi_cdb_atapassthrough16 import ATAPassThrough16
 from pyscsi.pyscsi.scsi_cdb_exchangemedium import ExchangeMedium
+from pyscsi.pyscsi.scsi_cdb_extended_copy_spc4 import ExtendedCopy as ExtendedCopy4
+from pyscsi.pyscsi.scsi_cdb_extended_copy_spc5 import ExtendedCopy as ExtendedCopy5
 from pyscsi.pyscsi.scsi_cdb_getlbastatus import GetLBAStatus
 from pyscsi.pyscsi.scsi_cdb_initelementstatus import InitializeElementStatus
 from pyscsi.pyscsi.scsi_cdb_initelementstatuswithrange import (
@@ -816,5 +818,57 @@ class SCSI(object):
         """
         opcode = self.device.opcodes.PERSISTENT_RESERVE_OUT
         cmd = PersistentReserveOut(opcode, service_action, scope, pr_type, **kwargs)
+        self.execute(cmd)
+        return cmd
+
+    def extendedcopy4(
+        self,
+        list_identifier=0,
+        sequential_striped=0,
+        nrcr=0,
+        priority=0,
+        target_descriptor_list=[],
+        segment_descriptor_list=[],
+        inline_data=bytearray(0),
+    ):
+        opcode = self.device.opcodes.EXTENDED_COPY
+        cmd = ExtendedCopy4(
+            opcode,
+            list_identifier,
+            sequential_striped,
+            nrcr,
+            priority,
+            target_descriptor_list,
+            segment_descriptor_list,
+            inline_data,
+        )
+        self.execute(cmd)
+        return cmd
+
+    def extendedcopy5(
+        self,
+        sequential_striped=0,
+        list_id_usage=0,
+        priority=0,
+        g_sense=0,
+        immed=0,
+        list_identifier=0,
+        cscd_descriptor_list=[],
+        segment_descriptor_list=[],
+        inline_data=bytearray(0),
+    ):
+        opcode = self.device.opcodes.EXTENDED_COPY
+        cmd = ExtendedCopy5(
+            opcode,
+            sequential_striped,
+            list_id_usage,
+            priority,
+            g_sense,
+            immed,
+            list_identifier,
+            cscd_descriptor_list,
+            segment_descriptor_list,
+            inline_data,
+        )
         self.execute(cmd)
         return cmd

--- a/pyscsi/pyscsi/scsi_cdb_extended_copy_spc4.py
+++ b/pyscsi/pyscsi/scsi_cdb_extended_copy_spc4.py
@@ -1,0 +1,740 @@
+# coding: utf-8
+
+# Copyright (C) 2023 by Brian Meagher<brian.meagher@ixsystems.com>
+# SPDX-FileCopyrightText: 2014 The python-scsi Authors
+#
+# SPDX-License-Identifier: LGPL-2.1-or-later
+
+from pyscsi.pyscsi.scsi_cdb_inquiry import Inquiry
+from pyscsi.pyscsi.scsi_command import SCSICommand
+from pyscsi.utils.converter import encode_dict
+
+#
+# SCSI ReportTargetPortGroups command and definitions
+#
+
+
+class ExtendedCopy(SCSICommand):
+    """
+    A class to hold information from a SPC-4 ExtendedCopy command to a scsi device
+    """
+
+    # See SPC-4 6.3.1 EXTENDED COPY command introduction
+    # Table 100 - EXTENDED COPY command
+    _cdb_bits = {
+        "opcode": [0xFF, 0],
+        "service_action": [0x1F, 1],
+        "parameter_list_length": [0xFFFFFFFF, 10],
+    }
+
+    # See SPC-4 6.3.1 EXTENDED COPY command introduction
+    # Table 101 - EXTENDED COPY parameter list
+    _parameter_list_bits = {
+        "list_identifier": [0xFF, 0],
+        "priority": [0x07, 1],
+        "nrcr": [0x10, 1],
+        "str": [0x20, 1],
+        "target_descriptor_list_length": [0xFFFF, 2],
+        "segment_descriptor_list_length": [0xFFFFFFFF, 8],
+        "inline_data_length": [0xFFFFFFFF, 12],
+    }
+
+    # See SPC-4 6.3.6.1 Target descriptors introduction
+    # Table 104 - Target descriptor format
+    _target_descriptor_bits = {
+        "descriptor_type_code": [0xFF, 0],
+        "peripheral_device_type": [0x1F, 1],
+        "lu_id_type": [0xC0, 1],
+        "relative_initiator_port_identifier": [0xFFFF, 2],
+    }
+
+    # See SPC-4 6.3.6.5 Device type specific target descriptor parameters for block device types
+    # Table 110 - Device type specific target descriptor parameters for block device types
+    _device_specific_target_descriptor_parameters_block = {
+        "pad": [0x04, 28],
+        "disk_block_length": [0xFFFFFF, 29],
+    }
+
+    # See SPC-4 6.3.6.6 Device type specific target descriptor parameters for sequential-access device types
+    # Table 111 - Device type specific target descriptor parameters for sequential-access device types
+    _device_specific_target_descriptor_parameters_sequential = {
+        "fixed": [0x01, 28],
+        "pad": [0x04, 28],
+        "stream_block_length": [0xFFFFFF, 29],
+    }
+
+    # See SPC-4 6.3.6.7 Device type specific target descriptor parameters for processor device types
+    # Table 113 - Device type specific target descriptor parameters for processor device types
+    _device_specific_target_descriptor_parameters_processor = {
+        "pad": [0x04, 28],
+    }
+
+    # See SPC-4 6.3.6.1 Target descriptors introduction,
+    # Table 103 - EXTENDED COPY target descriptor type codes
+    _target_descriptor_type_codes = {
+        0xE0: {"name": "Fibre Channel N_Port_Name target descriptor", "size": 32},
+        0xE1: {"name": "Fibre Channel N_Port_ID target descriptor", "size": 32},
+        0xE2: {
+            "name": "Fibre Channel N_Port_ID With N_Port_Name Checking target descriptor",
+            "size": 32,
+        },
+        0xE3: {"name": "Parallel Interface T_L target descriptor", "size": 32},
+        0xE4: {"name": "Identification descriptor target descriptor", "size": 32},
+        0xE5: {"name": "IPv4 target descriptor", "size": 32},
+        0xE6: {"name": "Alias target descriptor", "size": 32},
+        0xE7: {"name": "RDMA target descriptor", "size": 32},
+        0xE8: {"name": "IEEE 1394 EUI-64 target descriptor", "size": 32},
+        0xE9: {"name": "SAS Serial SCSI Protocol target descriptor", "size": 32},
+        0xEA: {"name": "IPv6 target descriptor", "size": 64},
+    }
+
+    # See SPC-4 6.3.6.3 Identification descriptor target descriptor format
+    # Table 108 - Identification descriptor target descriptor format
+    _target_designator_bits = {
+        "code_set": [0x0F, 0],
+        "association": [0x30, 1],
+        "designator_type": [0x0F, 1],
+        "designator_length": [0xFF, 3],
+    }
+
+    # See SPC-4 6.3.6.1 Target descriptors introduction
+    # Table 106 - Device type specific parameters in target descriptors
+    # Also SPC-4 6.4.2 Standard INQUIRY data
+    # Table 136 - Peripheral device type
+    _device_type_codes = {
+        0x00: {
+            "name": "Block",
+            "description": "Direct access block device (e.g., magnetic disk)",
+        },
+        0x01: {
+            "name": "Stream or Tape",
+            "description": "Sequential access device (e.g., magnetic tape)",
+        },
+        0x03: {"name": "Stream", "description": "Processor device"},
+        0x04: {
+            "name": "Block",
+            "description": "Write-once device (e.g., some optical disks)",
+        },
+        0x05: {"name": "Block", "description": "CD/DVD device"},
+        0x07: {
+            "name": "Block",
+            "description": "Optical memory device (e.g., some optical disks)",
+        },
+        0x0E: {
+            "name": "Block",
+            "description": "Simplified direct access device (e.g., magnetic disk)",
+        },
+    }
+
+    # See SPC-4 6.3.7.1 Segment descriptors introduction
+    # Table 114 - EXTENDED COPY segment descriptor type codes
+    _segment_descriptor_type_codes = {
+        0x00: {
+            "name": "block -> stream",
+            "description": "Copy from block device to stream device",
+        },
+        0x01: {
+            "name": "stream -> block",
+            "description": "Copy from stream device to block device",
+        },
+        0x02: {
+            "name": "block -> block",
+            "description": "Copy from block device to block device",
+        },
+        0x03: {
+            "name": "stream -> stream",
+            "description": "Copy from stream device to stream device",
+        },
+        0x04: {
+            "name": "inline -> stream",
+            "description": "Copy inline data to stream device",
+        },
+        0x05: {
+            "name": "embedded -> stream",
+            "description": "Copy embedded data to stream device",
+        },
+        0x06: {
+            "name": "stream -> discard",
+            "description": "Read from stream device and discard",
+        },
+        0x07: {
+            "name": "Verify",
+            "description": "Verify block or stream device operation",
+        },
+        0x08: {
+            "name": "block<o> -> stream",
+            "description": "Copy block device with offset to stream device",
+        },
+        0x09: {
+            "name": "stream -> block<o>",
+            "description": "Copy stream device to block device with offset",
+        },
+        0x0A: {
+            "name": "block<o> -> block<o>",
+            "description": "Copy block device with offset to block device with offset",
+        },
+        0x0B: {
+            "name": "block -> stream&application client",
+            "description": "Copy from block device to stream device and hold a copy of processed data for the application client",
+        },
+        0x0C: {
+            "name": "stream -> block&application client",
+            "description": "Copy from stream device to block device and hold a copy of processed data for the application client",
+        },
+        0x0D: {
+            "name": "block -> block&application client",
+            "description": "Copy from block device to block device and hold a copy of processed data for the application client",
+        },
+        0x0E: {
+            "name": "stream -> stream&application client",
+            "description": "Copy from stream device to stream device and hold a copy of processed data for the application client",
+        },
+        0x0F: {
+            "name": "stream -> discard&application client",
+            "description": "Read from stream device and hold a copy of processed data for the application client",
+        },
+        0x10: {
+            "name": "filemark -> tape",
+            "description": "Write filemarks to sequential access device",
+        },
+        0x11: {
+            "name": "space -> tape",
+            "description": "Space records or filemarks on sequential access device",
+        },
+        0x12: {
+            "name": "locate -> tape",
+            "description": "Locate on sequential access device",
+        },
+        0x13: {"name": "<i>tape -> <i>tape", "description": "Tape device image copy"},
+        0x14: {
+            "name": "Register persistent reservation key",
+            "description": "Register persistent reservation key",
+        },
+        0x15: {
+            "name": "Third party persistent reservations source I_T nexus",
+            "description": "Third party persistent reservations source I_T nexus",
+        },
+    }
+
+    # See SPC-4 6.3.7.3 Block device to stream device operations
+    # Table 118 - Block device to or from stream device segment descriptor
+    _segment_descriptor_bits_block_to_stream = {
+        "descriptor_type_code": [0xFF, 0],
+        "cat": [0x01, 1],
+        "descriptor_length": [0xFFFF, 2],
+        "source_target_descriptor_id": [0xFFFF, 4],
+        "destination_target_descriptor_id": [0xFFFF, 6],
+        "stream_device_transfer_length": [0xFFFFFF, 9],
+        "block_device_number_of_blocks": [0xFFFF, 14],
+        "block_device_logical_block_address": [0xFFFFFFFFFFFFFFFF, 16],
+    }
+
+    # See SPC-4 6.3.7.4 Stream device to block device operations
+    _segment_descriptor_bits_stream_to_block = _segment_descriptor_bits_block_to_stream
+
+    # See SPC-4 6.3.7.5 Block device to block device operations
+    # Table 119 - Block device to block device segment descriptor
+    _segment_descriptor_bits_block_to_block = {
+        "descriptor_type_code": [0xFF, 0],
+        "cat": [0x01, 1],
+        "dc": [0x02, 1],
+        "descriptor_length": [0xFFFF, 2],
+        "source_target_descriptor_id": [0xFFFF, 4],
+        "destination_target_descriptor_id": [0xFFFF, 6],
+        "block_device_number_of_blocks": [0xFFFF, 10],
+        "source_block_device_logical_block_address": [0xFFFFFFFFFFFFFFFF, 12],
+        "destination_block_device_logical_block_address": [0xFFFFFFFFFFFFFFFF, 20],
+    }
+
+    def __init__(
+        self,
+        opcode,
+        list_identifier=0,
+        sequential_striped=0,
+        nrcr=0,
+        priority=0,
+        target_descriptor_list=[],
+        segment_descriptor_list=[],
+        inline_data=bytearray(0),
+    ):
+        """
+        initialize a new instance
+
+        :param opcode: a OpCode instance
+
+        :param list_identifier Identifies the copy operation.  See SPC-4
+        6.3.1 EXTENDED COPY command introduction
+
+        :param sequential_striped: A sequential striped (STR) bit set to one
+        specifies to the copy manager that the majority of the block device
+        references in the parameter list represent sequential access of several
+        block devices that are striped.  A STR bit set to zero specifies to the
+        copy manager that disk references, if any, may not be sequential.
+
+        :param nrcr: No Receive Copy Results.  See SPC-4 6.3.1 EXTENDED COPY command introduction
+
+        :param priority: specifies the priority of data transfers resulting from
+        this EXTENDED COPY command relative to data transfers resulting from
+        other commands being processed by the device server contained within the
+        same logical unit as the copy manager.  All commands other than
+        third-party copy commands have a priority of 1h. Priority 0h is the
+        highest priority, with increasing values in the PRIORITY field
+        indicating lower priorities.
+
+        :param target_descriptor_list: list of target descriptors
+
+        :param segment_descriptor_list: list of segment descriptors.  See
+        SPC-4 6.3.7 Segment descriptors.  Each descriptor is a dic
+
+        :param inline_data: The inline data contains information that is
+        available for reference by target descriptors; or transfer by the copy
+        manager in response to segment descriptors.
+
+        EXAMPLE USAGE:
+
+        r = s1.extendedcopy4(
+            priority=1,
+            list_identifier=0x34,
+            target_descriptor_list=[
+                {
+                    "descriptor_type_code": "Identification descriptor target descriptor",
+                    "device_type_specific_parameters": {"disk_block_length": 512},
+                    "peripheral_device_type": 0,
+                    "target_descriptor_parameters": {
+                        "association": 0,
+                        "code_set": 1,
+                        "designator": {
+                            "ieee_company_id": 5807356,
+                            "naa": 6,
+                            "vendor_specific_identifier": 3140,
+                            "vendor_specific_identifier_extension": 14160104652988484981,
+                        },
+                        "designator_length": 16,
+                        "designator_type": 3,
+                    },
+                },
+                {
+                    "descriptor_type_code": "Identification descriptor target descriptor",
+                    "device_type_specific_parameters": {"disk_block_length": 512},
+                    "peripheral_device_type": 0,
+                    "target_descriptor_parameters": {
+                        "association": 0,
+                        "code_set": 1,
+                        "designator": {
+                            "ieee_company_id": 5807356,
+                            "naa": 6,
+                            "vendor_specific_identifier": 3809,
+                            "vendor_specific_identifier_extension": 17655255278882869693,
+                        },
+                        "designator_length": 16,
+                        "designator_type": 3,
+                    },
+                },
+            ],
+            segment_descriptor_list=[
+                {
+                    "block_device_number_of_blocks": 4,
+                    "dc": 1,
+                    "descriptor_type_code": "Copy from block device to block device",
+                    "destination_block_device_logical_block_address": 10,
+                    "destination_target_descriptor_id": 1,
+                    "source_block_device_logical_block_address": 1,
+                    "source_target_descriptor_id": 0,
+                }
+            ],
+        )
+
+        """
+        SCSICommand.__init__(self, opcode, 0, 0)
+
+        # payload
+        self.dataout = self.marshall_parameter_list(
+            list_identifier,
+            sequential_striped,
+            nrcr,
+            priority,
+            target_descriptor_list,
+            segment_descriptor_list,
+            inline_data,
+        )
+
+        # This is SPC-4 which has a service_action of 0, different than SPC-5
+        self.cdb = self.build_cdb(
+            opcode=self.opcode.value,
+            parameter_list_length=len(self.dataout),
+        )
+
+    @classmethod
+    def marshall_parameter_list(
+        cls,
+        list_identifier,
+        sequential_striped,
+        nrcr,
+        priority,
+        target_descriptor_list,
+        segment_descriptor_list,
+        inline_data,
+    ):
+        target_data = []
+        for target_dict in target_descriptor_list:
+            target_data.append(cls.marshall_target(target_dict))
+        target_descriptor_list_length = sum([len(item) for item in target_data])
+
+        segment_data = []
+        for segment_dict in segment_descriptor_list:
+            segment = cls.marshall_segment(segment_dict)
+            if segment:
+                segment_data.append(segment)
+            else:
+                raise ValueError("Failed to generate segment for %s" % segment_dict)
+        segment_descriptor_list_length = sum([len(item) for item in segment_data])
+
+        inline_data_length = len(inline_data)
+
+        # Write the header.  See 6.6.2 EXTENDED COPY parameter data,
+        # Table 99 — EXTENDED COPY parameter list
+        _r = bytearray(16)
+        _data = {
+            "list_identifier": list_identifier,
+            "priority": priority,
+            "nrcr": nrcr,
+            "str": sequential_striped,
+            "header_target_descriptor_list_length": 0x20,
+            "target_descriptor_list_length": target_descriptor_list_length,
+            "segment_descriptor_list_length": segment_descriptor_list_length,
+            "inline_data_length": inline_data_length,
+        }
+        encode_dict(_data, cls._parameter_list_bits, _r)
+
+        return _r + b"".join(target_data) + b"".join(segment_data) + inline_data
+
+    @classmethod
+    def marshall_target(cls, target_dict):
+        """
+        Marshall a target descriptor
+
+        :param target_dict: a dict with keys
+
+          descriptor_type_code:
+
+          peripheral_device_type:
+
+          lu_id_type:
+
+          relative_initiator_port_identifier:
+
+          param target_descriptor_parameters: Dictionary with parameters based on
+          the value of descriptor_type_code
+
+              descriptor_type_code == 0xE4, See SPC-4 6.6.5.6 Identification
+              Descriptor target descriptor format.  Keys:
+
+                code_set
+                designator_type
+                association
+                designator_length
+                designator
+
+          device_type_specific_parameters: A dict with keys that vary based on
+          peripheral_device_type.
+
+          For block, sequential or processor device types:
+            pad: The PAD bit is used in conjunction with the CAT bit in the
+            segment descriptor to determine what action should be taken if a
+            segment of the copy does not fit exactly into an integer number of
+            destination logical blocks
+
+          For block device type:
+            disk_block_length: If the DISK BLOCK LENGTH field is set to zero
+            and the PERIPHERAL DEVICE TYPE field is set to 00h, then the copy
+            manager shall determine the logical block length of the target
+            logical unit (e.g., by sending a READ CAPACITY command, and use
+            the result wherever the use of the DISK BLOCK LENGTH field is
+            required by this standard.
+
+          For the sequential access device type:
+            fixed: FIXED bit
+
+            stream_block_length: The contents of the FIXED bit and STREAM BLOCK
+            LENGTH field are combined with the STREAM DEVICE TRANSFER LENGTH
+            FIELD in the segment descriptor to determine the length of the
+            stream read or write operation as specified in SPC-4 6.3.6.6 Device
+            type specific target descriptor parameters for sequential-access
+            device types, Table 112 - Stream device transfer lengths
+
+        :return result: a byte array
+        """
+        # First check the keys
+        valid_keys = set(cls._target_descriptor_bits.keys()).union(
+            [
+                "target_descriptor_parameters",
+                "device_type_specific_parameters",
+            ]
+        )
+        provided_keys = set(target_dict.keys())
+        if not provided_keys.issubset(valid_keys):
+            for key in provided_keys:
+                raise ValueError(
+                    "Invalid key supplied: %s (should be one of %s)" % (key, valid_keys)
+                )
+
+        # Now check some values
+        descriptor_type_code = cls.get_code_int(
+            "descriptor_type_code", target_dict, cls._target_descriptor_type_codes
+        )
+        peripheral_device_type = cls.get_code_int(
+            "peripheral_device_type", target_dict, cls._device_type_codes
+        )
+
+        lu_id_type = target_dict.get("lu_id_type", 0)
+        if lu_id_type != 0:
+            raise ValueError("Invalid lu_id_type provided: %d" % lu_id_type)
+
+        relative_initiator_port_identifier = target_dict.get(
+            "relative_initiator_port_identifier", 0
+        )
+
+        numbytes = cls._target_descriptor_type_codes[descriptor_type_code]["size"]
+        _data = bytearray(numbytes)
+
+        #
+        # Write the header of the target descriptor
+        #
+        # See SPC-4 6.3.6.1 Target descriptors introduction
+        # Table 104 - Target descriptor format
+        encode_dict(
+            {
+                "descriptor_type_code": descriptor_type_code,
+                "peripheral_device_type": peripheral_device_type,
+                "lu_id_type": lu_id_type,
+                "relative_initiator_port_identifier": relative_initiator_port_identifier,
+            },
+            cls._target_descriptor_bits,
+            _data,
+        )
+
+        #
+        # target descriptor parameters
+        #
+        cls.marshall_target_descriptor_parameters(
+            descriptor_type_code,
+            _data,
+            target_dict.get("target_descriptor_parameters", {}),
+        )
+
+        #
+        # Device type specific parameters
+        #
+        params = target_dict.get("device_type_specific_parameters", {})
+        if peripheral_device_type in [0x00, 0x04, 0x05, 0x07, 0x0E]:
+            encode_dict(
+                {
+                    "pad": params.get("pad", 0),
+                    "disk_block_length": params.get("disk_block_length", 0),
+                },
+                cls._device_specific_target_descriptor_parameters_block,
+                _data,
+            )
+        elif peripheral_device_type == 0x01:
+            encode_dict(
+                {
+                    "fixed": params.get("fixed", 0),
+                    "pad": params.get("pad", 0),
+                    "stream_block_length": params.get("stream_block_length", 0),
+                },
+                cls._device_specific_target_descriptor_parameters_sequential,
+                _data,
+            )
+        elif peripheral_device_type == 0x03:
+            encode_dict(
+                {
+                    "pad": params.get("pad", 0),
+                },
+                cls._device_specific_target_descriptor_parameters_processor,
+                _data,
+            )
+
+        return _data
+
+    @classmethod
+    def marshall_target_descriptor_parameters(
+        cls, descriptor_type_code, data, target_descriptor_parameters
+    ):
+        """
+        Marshall the target descriptor parameters for a target descriptor.
+
+        :param descriptor_type_code: See SPC-4 6.3.6.1 Target descriptors introduction,
+        Table 103 - EXTENDED COPY target descriptor type codes
+
+        :param data: bytearray reppresenting the CSCD descriptor
+
+        :param target_descriptor_parameters: Dictionary with parameters based on
+        the value of descriptor_type_code
+
+          descriptor_type_code == 0xE4, See SPC-4 6.6.5.6 Identification
+          Descriptor CSCD descriptor format.  Keys:
+
+            code_set
+            designator_type
+            association
+            designator_length
+            designator
+
+        """
+        if descriptor_type_code == 0xE0:
+            # Fibre Channel N_Port_Name CSCD descriptor
+            pass
+        elif descriptor_type_code == 0xE1:
+            # Fibre Channel N_Port_ID CSCD descriptor
+            pass
+        elif descriptor_type_code == 0xE2:
+            # Fibre Channel N_Port_ID With N_Port_Name Checking CSCD descriptor
+            pass
+        elif descriptor_type_code == 0xE4:
+            # Identification Descriptor CSCD descriptor
+            #
+            # The structure shown in SPC-4 6.3.6.3 Identification descriptor target
+            # descriptor format, Table 108 — Identification Descriptor target
+            # descriptor format matches the format shown in SPC-4 7.7.4.1 Device
+            # Identification VPD page overview, Table 486 - Designation
+            # descriptor ... albeit at a different byte offset (and without the
+            # PROTOCOL IDENTIFIER or PIV fields)
+            #
+            # Therefore, we can reuse the Inquiry.marshall_designator class
+            # method here.  We implement our own marshall_designator_descriptor
+            # as we do NOT want the protocol_identifier and piv fields supported
+            # by inquiry.
+            designator = cls.marshall_designator_descriptor(
+                target_descriptor_parameters
+            )
+            data[4 : 4 + len(designator)] = designator
+            return
+        elif descriptor_type_code == 0xE5:
+            # IPv4 CSCD descriptor
+            pass
+        elif descriptor_type_code == 0xE6:
+            # Alias CSCD descriptor
+            pass
+        elif descriptor_type_code == 0xE7:
+            # RDMA CSCD descriptor
+            pass
+        elif descriptor_type_code == 0xE8:
+            # IEEE 1394 EUI-64 CSCD descriptor
+            pass
+        elif descriptor_type_code == 0xE9:
+            # SAS Serial SCSI Protocol CSCD descriptor
+            pass
+        elif descriptor_type_code == 0xEA:
+            # IPv6 CSCD descriptor
+            pass
+        elif descriptor_type_code == 0xEB:
+            # IP Copy Service CSCD descriptor
+            pass
+        elif descriptor_type_code == 0xEC:
+            # Multiple Device CSCD descriptor"
+            pass
+        elif descriptor_type_code == 0xFE:
+            # ROD CSCD descriptor
+            pass
+        else:
+            raise ValueError("Invalid descriptor type code: %s" % descriptor_type_code)
+
+        raise NotImplementedError(
+            "CSCD descriptor parameter not yet implemented for %s (%s)"
+            % (
+                hex(descriptor_type_code),
+                cls._target_descriptor_type_codes[descriptor_type_code]["name"],
+            )
+        )
+
+    @classmethod
+    def marshall_designator_descriptor(cls, data):
+        """
+        static helper method to marshall designator desciptor data
+
+        :param data: a dict with designator data
+        :return: a byte array
+        """
+        _r = bytearray(4)
+        encode_dict(data, cls._target_designator_bits, _r)
+
+        _r += Inquiry.marshall_designator(data["designator_type"], data["designator"])
+        _r[3] = len(_r) - 4
+        return _r
+
+    @classmethod
+    def marshall_segment(cls, segment_dict):
+        """
+        Marshall a segment descriptor
+
+        :param segment_dict: a dict with keys
+
+          descriptor_type_code:
+          cat:
+          dc:
+          fco:
+        """
+        descriptor_type_code = cls.get_code_int(
+            "descriptor_type_code", segment_dict, cls._segment_descriptor_type_codes
+        )
+
+        # Update the descriptor_type_code in case an int was not supplied
+        segment_dict["descriptor_type_code"] = descriptor_type_code
+
+        if descriptor_type_code in [0x00, 0x0B]:
+            return cls.encode_segment_dict(
+                segment_dict, cls._segment_descriptor_bits_block_to_stream, 24
+            )
+        elif descriptor_type_code in [0x01, 0x0C]:
+            return cls.encode_segment_dict(
+                segment_dict, cls._segment_descriptor_bits_stream_block, 24
+            )
+        elif descriptor_type_code in [0x02, 0x0D]:
+            return cls.encode_segment_dict(
+                segment_dict, cls._segment_descriptor_bits_block_to_block, 28
+            )
+
+        raise NotImplementedError(
+            "segment descriptor parameter not yet implemented for %s (%s)"
+            % (
+                hex(descriptor_type_code),
+                cls._segment_descriptor_type_codes[descriptor_type_code]["name"],
+            )
+        )
+
+    @classmethod
+    def encode_segment_dict(cls, data_dict, check_dict, numbytes):
+        data_dict["descriptor_length"] = numbytes - 4
+
+        valid_keys = set(check_dict.keys())
+        provided_keys = set(data_dict.keys())
+        if not provided_keys.issubset(valid_keys):
+            for key in provided_keys:
+                raise ValueError(
+                    "Invalid key supplied: %s (should be one of %s)" % (key, valid_keys)
+                )
+
+        _r = bytearray(numbytes)
+        encode_dict(data_dict, check_dict, _r)
+        return _r
+
+    @classmethod
+    def get_code_int(cls, key, datadict, table):
+        """
+        Return the integer value associated with the supplied value.
+        """
+        value = datadict.get(key)
+        if value is not None:
+            # Is value is a key to the table (usual case)
+            if value in table:
+                return value
+
+            # Is value is a name or description in the table
+            for k, v in table.items():
+                if value == v.get("name"):
+                    return k
+                if value == v.get("description"):
+                    return k
+
+        # Could not find value!
+        raise ValueError("Invalid %s provided: %s" % (key, value))

--- a/pyscsi/pyscsi/scsi_cdb_extended_copy_spc5.py
+++ b/pyscsi/pyscsi/scsi_cdb_extended_copy_spc5.py
@@ -1,0 +1,718 @@
+# coding: utf-8
+
+# Copyright (C) 2023 by Brian Meagher<brian.meagher@ixsystems.com>
+# SPDX-FileCopyrightText: 2014 The python-scsi Authors
+#
+# SPDX-License-Identifier: LGPL-2.1-or-later
+
+from pyscsi.pyscsi.scsi_cdb_inquiry import Inquiry
+from pyscsi.pyscsi.scsi_command import SCSICommand
+from pyscsi.utils.converter import encode_dict
+
+#
+# SCSI ReportTargetPortGroups command and definitions
+#
+
+
+class ExtendedCopy(SCSICommand):
+    """
+    A class to hold information from a SPC-5 ExtendedCopy command to a scsi device
+    """
+
+    # See SPC-5 6.6.1 EXTENDED COPY command introduction,
+    # Table 98 — EXTENDED COPY command
+    _cdb_bits = {
+        "opcode": [0xFF, 0],
+        "service_action": [0x1F, 1],
+        "parameter_list_length": [0xFFFFFFFF, 10],
+    }
+
+    # See SPC-5 6.6.2 EXTENDED COPY parameter data,
+    # Table 99 — EXTENDED COPY parameter list
+    _parameter_list_bits = {
+        "parameter_list_format": [0xFF, 0],
+        "priority": [0x07, 1],
+        "list_id_usage": [0x18, 1],
+        "str": [0x20, 1],
+        "header_cscd_descriptor_list_length": [0xFFFF, 2],
+        "immed": [0x01, 15],
+        "g_sense": [0x02, 15],
+        "header_cscd_descriptor_type_code": [0xFF, 16],
+        "list_identifier": [0xFFFFFFFF, 20],
+        "cscd_descriptor_list_length": [0xFFFF, 42],
+        "segment_descriptor_list_length": [0xFFFF, 44],
+        "inline_data_length": [0xFFFF, 46],
+    }
+
+    # See SPC-5 6.6.5.1 CSCD descriptors introduction,
+    # Table 104 — CSCD descriptor format
+    _cscd_descriptor_bits = {
+        "descriptor_type_code": [0xFF, 0],
+        "peripheral_device_type": [0x1F, 1],
+        "lu_id_type": [0xC0, 1],
+        "relative_initiator_port_identifier": [0xFFFF, 2],
+    }
+
+    # See SPC-5 6.6.5.3 Device type specific CSCD descriptor parameters for
+    # block device types, Table 108
+    _device_specific_cscd_descriptor_parameters_block = {
+        "pad": [0x04, 28],
+        "disk_block_length": [0xFFFFFF, 29],
+    }
+
+    # See SPC-5 6.6.5.4 Device type specific CSCD descriptor parameters for the
+    # sequential access device type
+    _device_specific_cscd_descriptor_parameters_sequential = {
+        "fixed": [0x01, 28],
+        "pad": [0x04, 28],
+        "stream_block_length": [0xFFFFFF, 29],
+    }
+
+    # See SPC-5 6.6.5.5 Device type specific CSCD descriptor parameters for the
+    # processor device type
+    _device_specific_cscd_descriptor_parameters_processor = {
+        "pad": [0x04, 28],
+    }
+
+    # See SPC-5 6.6.5.1 CSCD descriptors introduction, Table 103 — EXTENDED COPY
+    # CSCD descriptor type codes
+    _cscd_descriptor_type_codes = {
+        0xE0: {"name": "Fibre Channel N_Port_Name CSCD descriptor", "size": 32},
+        0xE1: {"name": "Fibre Channel N_Port_ID CSCD descriptor", "size": 32},
+        0xE2: {
+            "name": "Fibre Channel N_Port_ID With N_Port_Name Checking CSCD descriptor",
+            "size": 32,
+        },
+        0xE4: {"name": "Identification Descriptor CSCD descriptor", "size": 32},
+        0xE5: {"name": "IPv4 CSCD descriptor", "size": 32},
+        0xE6: {"name": "Alias CSCD descriptor", "size": 32},
+        0xE7: {"name": "RDMA CSCD descriptor", "size": 32},
+        0xE8: {"name": "IEEE 1394 EUI-64 CSCD descriptor", "size": 32},
+        0xE9: {"name": "SAS Serial SCSI Protocol CSCD descriptor", "size": 32},
+        0xEA: {"name": "IPv6 CSCD descriptor", "size": 64},
+        0xEB: {"name": "IP Copy Service CSCD descriptor", "size": 64},
+        0xEC: {"name": "Multiple Device CSCD descriptor", "size": 32},
+        0xFE: {"name": "ROD CSCD descriptor", "size": 32},
+    }
+
+    _cscd_designator_bits = {
+        "code_set": [0x0F, 0],
+        "association": [0x30, 1],
+        "designator_type": [0x0F, 1],
+        "designator_length": [0xFF, 3],
+    }
+
+    # See SPC-5 6.6.5.1 CSCD descriptors introduction, Table 106 — Device type
+    # specific parameters in CSCD descriptors.  See also SPC-5 6.7.2 Standard
+    # INQUIRY data, Table 150 — PERIPHERAL DEVICE TYPE field
+    _device_type_codes = {
+        0x00: {
+            "name": "Block",
+            "description": "Direct access block device (e.g., magnetic disk)",
+        },
+        0x01: {
+            "name": "Stream or Tape",
+            "description": "Sequential access device (e.g., magnetic tape)",
+        },
+        0x03: {"name": "Stream", "description": "Processor device"},
+        0x05: {"name": "Block", "description": "CD/DVD device"},
+        0x0E: {
+            "name": "Block",
+            "description": "Simplified direct access device (e.g., magnetic disk)",
+        },
+    }
+
+    # See SPC-5 6.6.6.1 Segment descriptors introduction, Table 119 — EXTENDED
+    # COPY segment descriptor type codes
+    _segment_descriptor_type_codes = {
+        0x00: {
+            "name": "block -> stream",
+            "description": "Copy from block device to stream device",
+        },
+        0x01: {
+            "name": "stream -> block",
+            "description": "Copy from stream device to block device",
+        },
+        0x02: {
+            "name": "block -> block",
+            "description": "Copy from block device to block device",
+        },
+        0x03: {
+            "name": "stream -> stream",
+            "description": "Copy from stream device to stream device",
+        },
+        0x04: {
+            "name": "inline -> stream",
+            "description": "Copy inline data to stream device",
+        },
+        0x05: {
+            "name": "embedded -> stream",
+            "description": "Copy embedded data to stream device",
+        },
+        0x06: {
+            "name": "stream -> discard",
+            "description": "Read from stream device and discard",
+        },
+        0x07: {"name": "Verify CSCD", "description": "Verify CSCD"},
+        0x08: {
+            "name": "block<o> -> stream",
+            "description": "Copy block device with offset to stream device",
+        },
+        0x09: {
+            "name": "stream -> block<o>",
+            "description": "Copy stream device to block device with offset",
+        },
+        0x0A: {
+            "name": "block<o> -> block<o>",
+            "description": "Copy block device with offset to block device with offset",
+        },
+        0x0B: {
+            "name": "block -> stream&application client",
+            "description": "Copy from block device to stream device and hold a copy of processed data for the application client",
+        },
+        0x0C: {
+            "name": "stream -> block&application client",
+            "description": "Copy from stream device to block device and hold a copy of processed data for the application client",
+        },
+        0x0D: {
+            "name": "block -> block&application client",
+            "description": "Copy from block device to block device and hold a copy of processed data for the application client",
+        },
+        0x0E: {
+            "name": "stream -> stream&application client",
+            "description": "Copy from stream device to stream device and hold a copy of processed data for the application client",
+        },
+        0x0F: {
+            "name": "stream -> discard&application client",
+            "description": "Read from stream device and hold a copy of processed data for the application client",
+        },
+        0x10: {
+            "name": "filemark -> tape",
+            "description": "Write filemarks to sequential access device",
+        },
+        0x13: {"name": "<i>tape -> <i>tape", "description": "Tape device image copy"},
+        0x14: {
+            "name": "Register persistent reservation key",
+            "description": "Register persistent reservation key",
+        },
+        0x15: {
+            "name": "Third party persistent reservations source I_T nexus",
+            "description": "Third party persistent reservations source I_T nexus",
+        },
+        0x16: {
+            "name": "<i>block -> <i>block",
+            "description": "Block device image copy",
+        },
+        0x17: {
+            "name": "positioning -> tape",
+            "description": "Positioning on sequential access device",
+        },
+        0x18: {
+            "name": "<loi>tape -> <loi>tape",
+            "description": "Copy logical objects from tape device to tape device",
+        },
+        0x19: {
+            "name": "<loi>tape -> <loi>tape mirror",
+            "description": "Create a mirror of the data stream as the tape is written",
+        },
+        0xBE: {
+            "name": "ROD <- block ranges<n>",
+            "description": "Populate ROD from one or more block ranges",
+        },
+        0xBF: {
+            "name": "ROD <- block range",
+            "description": "Populate ROD from one block range",
+        },
+    }
+
+    # See SPC-5 6.6.6.2 Block device to stream device functions
+    _segment_descriptor_bits_block_to_stream = {
+        "descriptor_type_code": [0xFF, 0],
+        "cat": [0x01, 1],
+        "descriptor_length": [0xFFFF, 2],
+        "source_cscd_descriptor_id": [0xFFFF, 4],
+        "destination_cscd_descriptor_id": [0xFFFF, 6],
+        "stream_device_transfer_length": [0xFFFFFF, 9],
+        "block_device_number_of_blocks": [0xFFFF, 14],
+        "block_device_logical_block_address": [0xFFFFFFFFFFFFFFFF, 16],
+    }
+
+    # See SPC-5 6.6.6.3 Stream device to block device functions
+    _segment_descriptor_bits_stream_to_block = {
+        "descriptor_type_code": [0xFF, 0],
+        "cat": [0x01, 1],
+        "descriptor_length": [0xFFFF, 2],
+        "source_cscd_descriptor_id": [0xFFFF, 4],
+        "destination_cscd_descriptor_id": [0xFFFF, 6],
+        "stream_device_transfer_length": [0xFFFFFF, 9],
+        "block_device_number_of_blocks": [0xFFFF, 14],
+        "block_device_logical_block_address": [0xFFFFFFFFFFFFFFFF, 16],
+    }
+
+    # See SPC-5 6.6.6.4 Block device to block device functions
+    _segment_descriptor_bits_block_to_block = {
+        "descriptor_type_code": [0xFF, 0],
+        "cat": [0x01, 1],
+        "dc": [0x02, 1],
+        "fco": [0x04, 1],
+        "descriptor_length": [0xFFFF, 2],
+        "source_cscd_descriptor_id": [0xFFFF, 4],
+        "destination_cscd_descriptor_id": [0xFFFF, 6],
+        "block_device_number_of_blocks": [0xFFFF, 10],
+        "source_block_device_logical_block_address": [0xFFFFFFFFFFFFFFFF, 12],
+        "destination_block_device_logical_block_address": [0xFFFFFFFFFFFFFFFF, 20],
+    }
+
+    def __init__(
+        self,
+        opcode,
+        sequential_striped=0,
+        list_id_usage=0,
+        priority=0,
+        g_sense=0,
+        immed=0,
+        list_identifier=0,
+        cscd_descriptor_list=[],
+        segment_descriptor_list=[],
+        inline_data=bytearray(0),
+    ):
+        """
+        initialize a new instance
+
+        :param opcode: a OpCode instance
+
+        :param sequential_striped: A sequential striped (STR) bit set to one
+        specifies to the copy manager that the majority of the block device
+        references in the parameter list represent sequential access of several
+        block devices that are striped.  A STR bit set to zero specifies to the
+        copy manager that disk references, if any, may not be sequential.
+
+        :param list_id_usage: specifies the usage of the LIST IDENTIFIER field
+        See SPC-5 6.6.3.2 LIST IDENTIFIER field and LIST ID USAGE field.
+
+        :param priority: specifies the priority of data transfers resulting from
+        this EXTENDED COPY command relative to data transfers resulting from
+        other commands being processed by the device server contained within the
+        same logical unit as the copy manager.  All commands other than
+        third-party copy commands have a priority of 1h. Priority 0h is the
+        highest priority, with increasing values in the PRIORITY field
+        indicating lower priorities.
+
+        :param g_sense: The good with sense data (G_SENSE) bit specifies
+        whether the copy manager is required to include sense data with GOOD
+        status.  See SPC-5 6.6.2 EXTENDED COPY parameter data
+
+        :param list_identifier Identifies the copy operation.  See SPC-5
+        6.6.3.2 LIST IDENTIFIER field and LIST ID USAGE field
+
+        :param immed: The immediate (IMMED) bit specifies whether the copy
+        manager returns status for the EXTENDED COPY command before the first
+        segment descriptor is processed
+
+        :param cscd_descriptor_list: list of CSCD descriptors
+
+        :param segment_descriptor_list: list of segment descriptors.  See
+        SPC-5 6.6.6 Segment descriptors.  Each descriptor is a dic
+
+        :param inline_data: The inline data contains information that is
+        available for reference by CSCD descriptors; or transfer by the copy
+        manager in response to segment descriptors.
+        """
+        SCSICommand.__init__(self, opcode, 0, 0)
+
+        # payload
+        self.dataout = self.marshall_parameter_list(
+            sequential_striped,
+            list_id_usage,
+            priority,
+            g_sense,
+            immed,
+            list_identifier,
+            cscd_descriptor_list,
+            segment_descriptor_list,
+            inline_data,
+        )
+
+        # SPC-5 has a service action of 1 (different than SPC-3 or SPC-4)
+        self.cdb = self.build_cdb(
+            opcode=self.opcode.value,
+            service_action=0x01,
+            parameter_list_length=len(self.dataout),
+        )
+
+    @classmethod
+    def marshall_parameter_list(
+        cls,
+        sequential_striped,
+        list_id_usage,
+        priority,
+        g_sense,
+        immed,
+        list_identifier,
+        cscd_descriptor_list,
+        segment_descriptor_list,
+        inline_data,
+    ):
+        cscd_data = []
+        for cscd_dict in cscd_descriptor_list:
+            cscd_data.append(cls.marshall_cscd(cscd_dict))
+        cscd_descriptor_list_length = sum([len(item) for item in cscd_data])
+
+        segment_data = []
+        for segment_dict in segment_descriptor_list:
+            segment = cls.marshall_segment(segment_dict)
+            if segment:
+                segment_data.append(segment)
+            else:
+                raise ValueError("Failed to generate segment for %s" % segment_dict)
+        segment_descriptor_list_length = sum([len(item) for item in segment_data])
+
+        inline_data_length = len(inline_data)
+
+        # Write the header.  See 6.6.2 EXTENDED COPY parameter data,
+        # Table 99 — EXTENDED COPY parameter list
+        _r = bytearray(48)
+        _data = {
+            "parameter_list_format": 1,
+            "priority": priority,
+            "list_id_usage": list_id_usage,
+            "str": sequential_striped,
+            "header_cscd_descriptor_list_length": 0x20,
+            "immed": immed,
+            "g_sense": g_sense,
+            "header_cscd_descriptor_type_code": 0xFF,
+            "list_identifier": list_identifier,
+            "cscd_descriptor_list_length": cscd_descriptor_list_length,
+            "segment_descriptor_list_length": segment_descriptor_list_length,
+            "inline_data_length": inline_data_length,
+        }
+        encode_dict(_data, cls._parameter_list_bits, _r)
+
+        return _r + b"".join(cscd_data) + b"".join(segment_data) + inline_data
+
+    @classmethod
+    def marshall_cscd(cls, cscd_dict):
+        """
+        Marshall a CSCD descriptor
+
+        :param cscd_dict: a dict with keys
+
+          descriptor_type_code:
+
+          peripheral_device_type:
+
+          lu_id_type:
+
+          relative_initiator_port_identifier:
+
+          param cscd_descriptor_parameters: Dictionary with parameters based on
+          the value of descriptor_type_code
+
+              descriptor_type_code == 0xE4, See SPC-4 6.6.5.6 Identification
+              Descriptor CSCD descriptor format.  Keys:
+
+                code_set
+                designator_type
+                association
+                designator_length
+                designator
+
+          device_type_specific_parameters: A dict with keys that vary based on
+          peripheral_device_type.
+
+          For block, sequential or processor device types:
+            pad: The PAD bit is used in conjunction with the CAT bit in the
+            segment descriptor to determine what action should be taken if a
+            segment of the copy does not fit exactly into an integer number of
+            destination logical blocks
+
+          For block device type:
+            disk_block_length: If the DISK BLOCK LENGTH field is set to zero
+            and the PERIPHERAL DEVICE TYPE field is set to 00h, then the copy
+            manager shall determine the logical block length of the CSCD
+            logical unit (e.g., by sending a READ CAPACITY command, and use
+            the result wherever the use of the DISK BLOCK LENGTH field is
+            required by this standard.
+
+          For the sequential access device type:
+            fixed: FIXED bit
+
+            stream_block_length: The contents of the FIXED bit and STREAM BLOCK
+            LENGTH field are combined with the STREAM DEVICE TRANSFER LENGTH
+            FIELD in the segment descriptor to determine the length of the
+            stream read or write as defined in SPC-5 6.6.5.4 Device type
+            specific CSCD descriptor parameters for the sequential access
+            device type, Table 110 — Stream device transfer lengths
+
+        :return result: a byte array
+        """
+        # First check the keys
+        valid_keys = set(cls._cscd_descriptor_bits.keys()).union(
+            [
+                "cscd_descriptor_parameters",
+                "device_type_specific_parameters",
+            ]
+        )
+        provided_keys = set(cscd_dict.keys())
+        if not provided_keys.issubset(valid_keys):
+            for key in provided_keys:
+                raise ValueError(
+                    "Invalid key supplied: %s (should be one of %s)" % (key, valid_keys)
+                )
+
+        # Now check some values
+        descriptor_type_code = cls.get_code_int(
+            "descriptor_type_code", cscd_dict, cls._cscd_descriptor_type_codes
+        )
+        peripheral_device_type = cls.get_code_int(
+            "peripheral_device_type", cscd_dict, cls._device_type_codes
+        )
+
+        lu_id_type = cscd_dict.get("lu_id_type", 0)
+        if lu_id_type != 0:
+            raise ValueError("Invalid lu_id_type provided: %d" % lu_id_type)
+
+        relative_initiator_port_identifier = cscd_dict.get(
+            "relative_initiator_port_identifier", 0
+        )
+
+        numbytes = cls._cscd_descriptor_type_codes[descriptor_type_code]["size"]
+        _data = bytearray(numbytes)
+
+        #
+        # Write the header of the CSCD descriptor
+        #
+        # See SPC-5 6.6.5.1 CSCD descriptors introduction,
+        # Table 104 — CSCD descriptor format
+        encode_dict(
+            {
+                "descriptor_type_code": descriptor_type_code,
+                "peripheral_device_type": peripheral_device_type,
+                "lu_id_type": lu_id_type,
+                "relative_initiator_port_identifier": relative_initiator_port_identifier,
+            },
+            cls._cscd_descriptor_bits,
+            _data,
+        )
+
+        #
+        # CSCD descriptor parameters
+        #
+        cls.marshall_cscd_descriptor_parameters(
+            descriptor_type_code, _data, cscd_dict.get("cscd_descriptor_parameters", {})
+        )
+
+        #
+        # Device type specific parameters
+        #
+        params = cscd_dict.get("device_type_specific_parameters", {})
+        if peripheral_device_type in [0x00, 0x05, 0x0E]:
+            encode_dict(
+                {
+                    "pad": params.get("pad", 0),
+                    "disk_block_length": params.get("disk_block_length", 0),
+                },
+                cls._device_specific_cscd_descriptor_parameters_block,
+                _data,
+            )
+        elif peripheral_device_type == 0x01:
+            encode_dict(
+                {
+                    "fixed": params.get("fixed", 0),
+                    "pad": params.get("pad", 0),
+                    "stream_block_length": params.get("stream_block_length", 0),
+                },
+                cls._device_specific_cscd_descriptor_parameters_sequential,
+                _data,
+            )
+        elif peripheral_device_type == 0x03:
+            encode_dict(
+                {
+                    "pad": params.get("pad", 0),
+                },
+                cls._device_specific_cscd_descriptor_parameters_processor,
+                _data,
+            )
+
+        # CSCD descriptor extensions
+        return _data
+
+    @classmethod
+    def marshall_cscd_descriptor_parameters(
+        cls, descriptor_type_code, data, cscd_descriptor_parameters
+    ):
+        """
+        Marshall the CSCD descriptor parameters for a CSCD descriptor.
+
+        :param descriptor_type_code: See SPC-5 6.6.5.1 CSCD descriptors
+        introduction, Table 103 — EXTENDED COPY CSCD descriptor type codes
+
+        :param data: bytearray reppresenting the CSCD descriptor
+
+        :param cscd_descriptor_parameters: Dictionary with parameters based on
+        the value of descriptor_type_code
+
+          descriptor_type_code == 0xE4, See SPC-4 6.6.5.6 Identification
+          Descriptor CSCD descriptor format.  Keys:
+
+            code_set
+            designator_type
+            association
+            designator_length
+            designator
+
+        """
+        if descriptor_type_code == 0xE0:
+            # Fibre Channel N_Port_Name CSCD descriptor
+            pass
+        elif descriptor_type_code == 0xE1:
+            # Fibre Channel N_Port_ID CSCD descriptor
+            pass
+        elif descriptor_type_code == 0xE2:
+            # Fibre Channel N_Port_ID With N_Port_Name Checking CSCD descriptor
+            pass
+        elif descriptor_type_code == 0xE4:
+            # Identification Descriptor CSCD descriptor
+            #
+            # The structure shown in SPC-5 6.6.5.6 Identification Descriptor
+            # CSCD descriptor format, Table 112 — Identification Descriptor CSCD
+            # descriptor format matches the format shown in 7.7.6.1 Device
+            # Identification VPD page overview, Table 515 — Designation
+            # descriptor ... albeit at a different byte offset
+            #
+            # Therefore, we can reuse the Inquiry.marshall_designator class
+            # method here.  We implement our own marshall_designator_descriptor
+            # as we do NOT want the protocol_identifier and piv fields supported
+            # by inquiry.
+            designator = cls.marshall_designator_descriptor(cscd_descriptor_parameters)
+            data[4 : 4 + len(designator)] = designator
+            return
+        elif descriptor_type_code == 0xE5:
+            # IPv4 CSCD descriptor
+            pass
+        elif descriptor_type_code == 0xE6:
+            # Alias CSCD descriptor
+            pass
+        elif descriptor_type_code == 0xE7:
+            # RDMA CSCD descriptor
+            pass
+        elif descriptor_type_code == 0xE8:
+            # IEEE 1394 EUI-64 CSCD descriptor
+            pass
+        elif descriptor_type_code == 0xE9:
+            # SAS Serial SCSI Protocol CSCD descriptor
+            pass
+        elif descriptor_type_code == 0xEA:
+            # IPv6 CSCD descriptor
+            pass
+        elif descriptor_type_code == 0xEB:
+            # IP Copy Service CSCD descriptor
+            pass
+        elif descriptor_type_code == 0xEC:
+            # Multiple Device CSCD descriptor"
+            pass
+        elif descriptor_type_code == 0xFE:
+            # ROD CSCD descriptor
+            pass
+        else:
+            raise ValueError("Invalid descriptor type code: %s" % descriptor_type_code)
+
+        raise NotImplementedError(
+            "CSCD descriptor parameter not yet implemented for %s (%s)"
+            % (
+                hex(descriptor_type_code),
+                cls._cscd_descriptor_type_codes[descriptor_type_code]["name"],
+            )
+        )
+
+    @classmethod
+    def marshall_designator_descriptor(cls, data):
+        """
+        static helper method to marshall designator desciptor data
+
+        :param data: a dict with designator data
+        :return: a byte array
+        """
+        _r = bytearray(4)
+        encode_dict(data, cls._cscd_designator_bits, _r)
+
+        _r += Inquiry.marshall_designator(data["designator_type"], data["designator"])
+        _r[3] = len(_r) - 4
+        return _r
+
+    @classmethod
+    def marshall_segment(cls, segment_dict):
+        """
+        Marshall a segment descriptor
+
+        :param segment_dict: a dict with keys
+
+          descriptor_type_code:
+          cat:
+          dc:
+          fco:
+        """
+        descriptor_type_code = cls.get_code_int(
+            "descriptor_type_code", segment_dict, cls._segment_descriptor_type_codes
+        )
+
+        # Update the descriptor_type_code in case an int was not supplied
+        segment_dict["descriptor_type_code"] = descriptor_type_code
+
+        if descriptor_type_code in [0x00, 0x0B]:
+            return cls.encode_segment_dict(
+                segment_dict, cls._segment_descriptor_bits_block_to_stream, 24
+            )
+        elif descriptor_type_code in [0x01, 0x0C]:
+            return cls.encode_segment_dict(
+                segment_dict, cls._segment_descriptor_bits_stream_block, 24
+            )
+        elif descriptor_type_code in [0x02, 0x0D]:
+            return cls.encode_segment_dict(
+                segment_dict, cls._segment_descriptor_bits_block_to_block, 28
+            )
+
+        raise NotImplementedError(
+            "segment descriptor parameter not yet implemented for %s (%s)"
+            % (
+                hex(descriptor_type_code),
+                cls._segment_descriptor_type_codes[descriptor_type_code]["name"],
+            )
+        )
+
+    @classmethod
+    def encode_segment_dict(cls, data_dict, check_dict, numbytes):
+        data_dict["descriptor_length"] = numbytes - 4
+
+        valid_keys = set(check_dict.keys())
+        provided_keys = set(data_dict.keys())
+        if not provided_keys.issubset(valid_keys):
+            for key in provided_keys:
+                raise ValueError(
+                    "Invalid key supplied: %s (should be one of %s)" % (key, valid_keys)
+                )
+
+        _r = bytearray(numbytes)
+        encode_dict(data_dict, check_dict, _r)
+        return _r
+
+    @classmethod
+    def get_code_int(cls, key, datadict, table):
+        """
+        Return the integer value associated with the supplied value.
+        """
+        value = datadict.get(key)
+        if value is not None:
+            # Is value is a key to the table (usual case)
+            if value in table:
+                return value
+
+            # Is value is a name or description in the table
+            for k, v in table.items():
+                if value == v.get("name"):
+                    return k
+                if value == v.get("description"):
+                    return k
+
+        # Could not find value!
+        raise ValueError("Invalid %s provided: %s" % (key, value))

--- a/pyscsi/pyscsi/scsi_cdb_inquiry.py
+++ b/pyscsi/pyscsi/scsi_cdb_inquiry.py
@@ -269,7 +269,7 @@ class Inquiry(SCSICommand):
 
         if _type == cls.DESIGNATOR.NAA:
             _r = bytearray(16)
-            convert.decode_bits(data, cls._naa_type_bits, _r)
+            convert.encode_dict(data, cls._naa_type_bits, _r)
             if data["naa"] == cls.NAA.IEEE_EXTENDED:
                 convert.encode_dict(data, cls._naa_ieee_extended_bits, _r)
                 return _r[:8]

--- a/tests/test_cdb_extended_copy_spc4.py
+++ b/tests/test_cdb_extended_copy_spc4.py
@@ -1,0 +1,302 @@
+# coding: utf-8
+
+# Copyright (C) 2023 by Brian Meagher <brian.meagher@ixsystems.com>
+# SPDX-FileCopyrightText: 2014 The python-scsi Authors
+#
+# SPDX-License-Identifier: LGPL-2.1-or-later
+
+import unittest
+
+from pyscsi.pyscsi.scsi_cdb_extended_copy_spc4 import ExtendedCopy
+from pyscsi.pyscsi.scsi_enum_command import spc
+from pyscsi.pyscsi.scsi_enum_inquiry import ASSOCIATION, CODE_SET, DESIGNATOR, NAA
+from pyscsi.utils.converter import scsi_ba_to_int
+from tests.mock_device import MockDevice, MockSCSI
+
+
+class CdbExtendedCopyTest(unittest.TestCase):
+    def spstr(self, string_with_spaces):
+        return string_with_spaces.replace(" ", "")
+
+    def check_hex_str(self, hexstr, bytedict):
+        count = int(len(hexstr) / 2)
+        checkbytes = bytearray(count)
+        for key in bytedict:
+            checkbytes[key] = bytedict[key]
+        self.assertEqual(hexstr, checkbytes.hex())
+
+    def test_main(self):
+        with MockSCSI(MockDevice(spc)) as s:
+            r = s.extendedcopy4()
+            self.assertIsInstance(r, ExtendedCopy)
+            cdb = r.cdb
+            self.assertEqual(cdb[0], s.device.opcodes.EXTENDED_COPY.value)
+            self.assertEqual(
+                cdb[1] & 0x1F,
+                0,
+            )
+            self.assertEqual(cdb[2], 0x00)
+            self.assertEqual(cdb[2:10], bytearray(8))
+            self.assertEqual(scsi_ba_to_int(cdb[10:14]), 16)
+            self.assertEqual(cdb[14], 0)
+            self.assertEqual(len(cdb), 16)
+            cdb = r.unmarshall_cdb(cdb)
+            self.assertEqual(cdb["opcode"], s.device.opcodes.EXTENDED_COPY.value)
+            self.assertEqual(
+                cdb["service_action"],
+                0,
+            )
+            ExtendedCopy.unmarshall_cdb(ExtendedCopy.marshall_cdb(cdb))
+
+            self.assertEqual(r.cdb.hex(), "83000000000000000000000000100000")
+            self.assertEqual(len(r.dataout), 16)
+            self.check_hex_str(r.dataout.hex(), {})
+
+            # LIST IDENTIFIER
+            r = s.extendedcopy4(list_identifier=0x50)
+            self.check_hex_str(r.dataout.hex(), {0: 0x50})
+
+            # STR
+            r = s.extendedcopy4(sequential_striped=1)
+            self.check_hex_str(r.dataout.hex(), {1: 0x20})
+
+            # NRCR
+            r = s.extendedcopy4(nrcr=1)
+            self.check_hex_str(r.dataout.hex(), {1: 0x10})
+
+            # PRIORITY
+            r = s.extendedcopy4(priority=1)
+            self.check_hex_str(r.dataout.hex(), {1: 0x01})
+
+            r = s.extendedcopy4(sequential_striped=1, nrcr=1, priority=7)
+            self.check_hex_str(r.dataout.hex(), {1: 0x37})
+
+            r = s.extendedcopy4(list_identifier=9, sequential_striped=1, priority=5)
+            self.check_hex_str(r.dataout.hex(), {0: 9, 1: 0x25})
+
+            # INLINE DATA
+            r = s.extendedcopy4(inline_data=bytearray.fromhex("deadbeef"))
+            self.assertEqual(len(r.dataout), 20)
+            self.assertEqual(scsi_ba_to_int(r.cdb[10:14]), 20)
+            self.check_hex_str(
+                r.dataout.hex(),
+                {
+                    15: 4,
+                    16: 0xDE,
+                    17: 0xAD,
+                    18: 0xBE,
+                    19: 0xEF,
+                },
+            )
+
+            # target
+            r = s.extendedcopy4(
+                target_descriptor_list=[
+                    {
+                        "descriptor_type_code": "Identification descriptor target descriptor",
+                        "peripheral_device_type": 0x00,
+                        "relative_initiator_port_identifier": 42,
+                        "target_descriptor_parameters": {
+                            "designator_type": DESIGNATOR.VENDOR_SPECIFIC,
+                            "designator": {
+                                "vendor_specific": bytearray.fromhex("deadbeef")
+                            },
+                        },
+                        "device_type_specific_parameters": {
+                            "pad": 1,
+                        },
+                    }
+                ]
+            )
+            # EXTENDED COPY parameter list: 16 bytes
+            # One target descriptor:        32 bytes (for this descriptor_type_code)
+            # Total bytes                   48
+            self.assertEqual(len(r.dataout), 48)
+            self.assertEqual(scsi_ba_to_int(r.cdb[10:14]), 48)
+            self.check_hex_str(
+                r.dataout.hex(),
+                {
+                    3: 0x20,
+                    16 + 0: 0xE4,  # Identification Descriptor target descriptor
+                    16 + 1: 0x00,  # Peripheral Device Type
+                    16 + 3: 42,  # relative_initiator_port_identifier
+                    16 + 7: 4,  # designator length
+                    16 + 8: 0xDE,
+                    16 + 9: 0xAD,
+                    16 + 10: 0xBE,
+                    16 + 11: 0xEF,
+                    16 + 28 + 0: 4,  # pad
+                },
+            )
+
+            r = s.extendedcopy4(
+                list_identifier=0xAA,
+                target_descriptor_list=[
+                    {
+                        "descriptor_type_code": "Identification descriptor target descriptor",
+                        "peripheral_device_type": 0x05,
+                        "target_descriptor_parameters": {
+                            "association": ASSOCIATION.ASSOCIATED_WITH_LUN,
+                            "code_set": CODE_SET.BINARY,
+                            "designator_type": DESIGNATOR.NAA,
+                            "designator": {
+                                "naa": NAA.IEEE_REGISTERED_EXTENDED,
+                                "ieee_company_id": 0x589CFC,
+                                "vendor_specific_identifier": 0x00000C44,
+                                "vendor_specific_identifier_extension": 0xC482CC288FBC0D75,
+                            },
+                        },
+                        "device_type_specific_parameters": {
+                            "disk_block_length": 512,
+                        },
+                    }
+                ],
+            )
+
+            self.assertEqual(len(r.dataout), 48)
+            self.assertEqual(scsi_ba_to_int(r.cdb[10:14]), 48)
+            self.check_hex_str(
+                r.dataout.hex(),
+                {
+                    # LIST IDENTIFIER
+                    0: 0xAA,
+                    # TARGET DESCRIPTOR LIST LENGTH (LSB)
+                    3: 0x20,
+                    16 + 0: 0xE4,  # Identification Descriptor target descriptor
+                    16 + 1: 0x05,  # Peripheral Device Type
+                    16 + 4: 0x01,  # CODE_SET.BINARY: 0x01
+                    # ASSOCIATION.ASSOCIATED_WITH_LUN: 0x00, DESIGNATOR.NAA: 0x03
+                    16 + 5: 0x03,
+                    # See 7.7.6.6.5 NAA IEEE Registered Extended designator format: 16 bytes
+                    16 + 7: 0x10,
+                    # NAA: 58 9C FC | 00 00 0C 44 | C4 82 CC 28 8F BC 0D 75
+                    # NAA:  5 89 CF C|0 00 00 0C 44 | C4 82 CC 28 8F BC 0D 75
+                    # NAA.IEEE_REGISTERED_EXTENDED: 6, first nibble of ieee_company_id: 5
+                    16 + 8: 0x65,
+                    16 + 9: 0x89,
+                    16 + 10: 0xCF,
+                    16 + 11: 0xC0,
+                    16 + 12: 0x00,
+                    16 + 13: 0x00,
+                    16 + 14: 0x0C,
+                    16 + 15: 0x44,
+                    16 + 16: 0xC4,
+                    16 + 17: 0x82,
+                    16 + 18: 0xCC,
+                    16 + 19: 0x28,
+                    16 + 20: 0x8F,
+                    16 + 21: 0xBC,
+                    16 + 22: 0x0D,
+                    16 + 23: 0x75,
+                    16 + 30: 2,  # disk block length (512 == 0x200) SPC-4 6.3.6.5
+                },
+            )
+
+            r = s.extendedcopy4(
+                target_descriptor_list=[
+                    {
+                        "descriptor_type_code": "Identification descriptor target descriptor",
+                        "peripheral_device_type": "Stream or Tape",
+                        "target_descriptor_parameters": {
+                            "association": ASSOCIATION.ASSOCIATED_WITH_LUN,
+                            "code_set": CODE_SET.ASCII,
+                            "designator_type": DESIGNATOR.T10_VENDOR_ID,
+                            "designator": {
+                                "t10_vendor_id": "TrueNAS ".encode("ascii"),
+                                "vendor_specific_id": "test123".encode("ascii"),
+                            },
+                        },
+                        "device_type_specific_parameters": {
+                            "pad": 1,
+                            "fixed": 1,
+                            "stream_block_length": 1024,
+                        },
+                    }
+                ]
+            )
+            self.assertEqual(len(r.dataout), 48)
+            self.assertEqual(scsi_ba_to_int(r.cdb[10:14]), 48)
+            self.check_hex_str(
+                r.dataout.hex(),
+                {
+                    # TARGET DESCRIPTOR LIST LENGTH (LSB)
+                    3: 0x20,
+                    16 + 0: 0xE4,  # Identification Descriptor target descriptor
+                    16 + 1: 0x01,  # Peripheral Device Type
+                    16 + 4: 0x02,  # CODE_SET.ASCII: 0x02
+                    # ASSOCIATION.ASSOCIATED_WITH_LUN: 0x00, DESIGNATOR.T10_VENDOR_ID: 0x01
+                    16 + 5: 0x01,
+                    16 + 7: 0x0F,  # len("TrueNAS " + "test123") == 15
+                    # See SPC-4 7.7.4.4 T10 vendor ID based designator format
+                    16 + 8: ord("T"),
+                    16 + 9: ord("r"),
+                    16 + 10: ord("u"),
+                    16 + 11: ord("e"),
+                    16 + 12: ord("N"),
+                    16 + 13: ord("A"),
+                    16 + 14: ord("S"),
+                    16 + 15: ord(" "),
+                    16 + 16: ord("t"),
+                    16 + 17: ord("e"),
+                    16 + 18: ord("s"),
+                    16 + 19: ord("t"),
+                    16 + 20: ord("1"),
+                    16 + 21: ord("2"),
+                    16 + 22: ord("3"),
+                    16 + 28: 5,  # pad & fixed, see SPC-4 6.3.6.6
+                    16 + 30: 4,  # stream block length (1024 == 0x400)
+                },
+            )
+
+            # INLINE DATA
+            r = s.extendedcopy4(
+                list_identifier=0x12,
+                segment_descriptor_list=[
+                    {
+                        "descriptor_type_code": "Copy from block device to block device",
+                        "dc": 1,
+                        "source_target_descriptor_id": 1,
+                        "destination_target_descriptor_id": 2,
+                        "block_device_number_of_blocks": 1024,
+                        "source_block_device_logical_block_address": 2048,
+                        "destination_block_device_logical_block_address": 4096,
+                    }
+                ],
+                inline_data=bytearray.fromhex("deadbeef"),
+            )
+            # length 16 + 28 + 4
+            self.assertEqual(len(r.dataout), 48)
+            self.assertEqual(scsi_ba_to_int(r.cdb[10:14]), 48)
+            self.check_hex_str(
+                r.dataout.hex(),
+                {
+                    # LIST IDENTIFIER
+                    0: 0x12,
+                    # SEGMENT DESCRIPTOR LIST LENGTH (LSB)
+                    # SPC-4 6.3.7.5 Block device to block device operations => len 28
+                    11: 28,
+                    # INLINE DATA LENGTH (LSB)
+                    15: 4,
+                    # DESCRIPTOR TYPE CODE: 0x02
+                    16 + 0: 0x02,
+                    # DC: 1
+                    16 + 1: 0x02,
+                    # DESCRIPTOR LENGTH (LSB): 24
+                    16 + 3: 0x18,
+                    # SOURCE TARGET DESCRIPTOR ID (LSB): 1
+                    16 + 5: 1,
+                    # DESTINATION TARGET DESCRIPTOR ID (LSB): 2
+                    16 + 7: 2,
+                    # BLOCK DEVICE NUMBER OF BLOCKS (MSB) 0x04 (1024 == 0x400)
+                    16 + 10: 0x04,
+                    # SOURCE BLOCK DEVICE LOGICAL BLOCK ADDRESS: (2048 == 0x800)
+                    16 + 18: 0x08,
+                    # DESTINATION BLOCK DEVICE LOGICAL BLOCK: (4096 = 0x1000)
+                    16 + 26: 0x10,
+                    # INLINE DATA
+                    16 + 28 + 0: 0xDE,
+                    16 + 28 + 1: 0xAD,
+                    16 + 28 + 2: 0xBE,
+                    16 + 28 + 3: 0xEF,
+                },
+            )

--- a/tests/test_cdb_extended_copy_spc5.py
+++ b/tests/test_cdb_extended_copy_spc5.py
@@ -1,0 +1,324 @@
+# coding: utf-8
+
+# Copyright (C) 2023 by Brian Meagher <brian.meagher@ixsystems.com>
+# SPDX-FileCopyrightText: 2014 The python-scsi Authors
+#
+# SPDX-License-Identifier: LGPL-2.1-or-later
+
+import unittest
+
+from pyscsi.pyscsi.scsi_cdb_extended_copy_spc5 import ExtendedCopy
+from pyscsi.pyscsi.scsi_enum_command import spc
+from pyscsi.pyscsi.scsi_enum_inquiry import ASSOCIATION, CODE_SET, DESIGNATOR, NAA
+from pyscsi.utils.converter import scsi_ba_to_int
+from tests.mock_device import MockDevice, MockSCSI
+
+
+class CdbExtendedCopyTest(unittest.TestCase):
+    def spstr(self, string_with_spaces):
+        return string_with_spaces.replace(" ", "")
+
+    def check_hex_str(self, hexstr, bytedict):
+        count = int(len(hexstr) / 2)
+        checkbytes = bytearray(count)
+        for key in bytedict:
+            checkbytes[key] = bytedict[key]
+        self.assertEqual(hexstr, checkbytes.hex())
+
+    def test_main(self):
+        with MockSCSI(MockDevice(spc)) as s:
+            r = s.extendedcopy5()
+            self.assertIsInstance(r, ExtendedCopy)
+            cdb = r.cdb
+            self.assertEqual(cdb[0], s.device.opcodes.EXTENDED_COPY.value)
+            self.assertEqual(
+                cdb[1] & 0x1F,
+                1,
+            )
+            self.assertEqual(cdb[2], 0x00)
+            self.assertEqual(cdb[2:10], bytearray(8))
+            self.assertEqual(scsi_ba_to_int(cdb[10:14]), 48)
+            self.assertEqual(cdb[14], 0)
+            self.assertEqual(len(cdb), 16)
+            cdb = r.unmarshall_cdb(cdb)
+            self.assertEqual(cdb["opcode"], s.device.opcodes.EXTENDED_COPY.value)
+            self.assertEqual(
+                cdb["service_action"],
+                1,
+            )
+            ExtendedCopy.unmarshall_cdb(ExtendedCopy.marshall_cdb(cdb))
+
+            self.assertEqual(r.cdb.hex(), "83010000000000000000000000300000")
+            self.assertEqual(len(r.dataout), 48)
+            self.check_hex_str(r.dataout.hex(), {0: 1, 3: 0x20, 16: 0xFF})
+
+            # STR
+            r = s.extendedcopy5(sequential_striped=1)
+            self.check_hex_str(r.dataout.hex(), {0: 1, 1: 0x20, 3: 0x20, 16: 0xFF})
+
+            # LIST ID USAGE
+            r = s.extendedcopy5(list_id_usage=1)
+            self.check_hex_str(r.dataout.hex(), {0: 1, 1: 0x08, 3: 0x20, 16: 0xFF})
+            r = s.extendedcopy5(list_id_usage=2)
+            self.check_hex_str(r.dataout.hex(), {0: 1, 1: 0x10, 3: 0x20, 16: 0xFF})
+            r = s.extendedcopy5(list_id_usage=3)
+            self.check_hex_str(r.dataout.hex(), {0: 1, 1: 0x18, 3: 0x20, 16: 0xFF})
+
+            # PRIORITY
+            r = s.extendedcopy5(priority=1)
+            self.check_hex_str(r.dataout.hex(), {0: 1, 1: 0x01, 3: 0x20, 16: 0xFF})
+            r = s.extendedcopy5(priority=7)
+            self.check_hex_str(r.dataout.hex(), {0: 1, 1: 0x07, 3: 0x20, 16: 0xFF})
+
+            r = s.extendedcopy5(sequential_striped=1, list_id_usage=2, priority=5)
+            self.check_hex_str(r.dataout.hex(), {0: 1, 1: 0x35, 3: 0x20, 16: 0xFF})
+
+            # G_SENSE
+            r = s.extendedcopy5(g_sense=1)
+            self.check_hex_str(r.dataout.hex(), {0: 1, 3: 0x20, 15: 0x02, 16: 0xFF})
+
+            # IMMED
+            r = s.extendedcopy5(immed=1)
+            self.check_hex_str(r.dataout.hex(), {0: 1, 3: 0x20, 15: 0x01, 16: 0xFF})
+
+            # LIST IDENTIFIER
+            r = s.extendedcopy5(list_identifier=255)
+            self.check_hex_str(r.dataout.hex(), {0: 1, 3: 0x20, 23: 0xFF, 16: 0xFF})
+            r = s.extendedcopy5(list_identifier=256)
+            self.check_hex_str(r.dataout.hex(), {0: 1, 3: 0x20, 22: 0x01, 16: 0xFF})
+            r = s.extendedcopy5(list_identifier=257)
+            self.check_hex_str(
+                r.dataout.hex(), {0: 1, 3: 0x20, 22: 0x01, 23: 0x01, 16: 0xFF}
+            )
+
+            # INLINE DATA
+            r = s.extendedcopy5(inline_data=bytearray.fromhex("deadbeef"))
+            self.assertEqual(len(r.dataout), 52)
+            self.assertEqual(scsi_ba_to_int(r.cdb[10:14]), 52)
+            self.check_hex_str(
+                r.dataout.hex(),
+                {
+                    0: 1,
+                    3: 0x20,
+                    16: 0xFF,
+                    47: 4,
+                    48: 0xDE,
+                    49: 0xAD,
+                    50: 0xBE,
+                    51: 0xEF,
+                },
+            )
+
+            # CSCD
+            r = s.extendedcopy5(
+                cscd_descriptor_list=[
+                    {
+                        "descriptor_type_code": "Identification Descriptor CSCD descriptor",
+                        "peripheral_device_type": 0x00,
+                        "relative_initiator_port_identifier": 42,
+                        "cscd_descriptor_parameters": {
+                            "designator_type": DESIGNATOR.VENDOR_SPECIFIC,
+                            "designator": {
+                                "vendor_specific": bytearray.fromhex("deadbeef")
+                            },
+                        },
+                        "device_type_specific_parameters": {
+                            "pad": 1,
+                        },
+                    }
+                ]
+            )
+            # EXTENDED COPY parameter list: 48 bytes
+            # One CSCD descriptor:          32 bytes (for this descriptor_type_code)
+            # Total bytes                   80
+            self.assertEqual(len(r.dataout), 80)
+            self.assertEqual(scsi_ba_to_int(r.cdb[10:14]), 80)
+            self.check_hex_str(
+                r.dataout.hex(),
+                {
+                    0: 1,
+                    3: 0x20,
+                    16: 0xFF,
+                    43: 32,
+                    48: 0xE4,  # Identification Descriptor CSCD descriptor
+                    49: 0x00,  # Peripheral Device Type
+                    51: 42,  # relative_initiator_port_identifier
+                    55: 4,  # designator length
+                    56: 0xDE,
+                    57: 0xAD,
+                    58: 0xBE,
+                    59: 0xEF,
+                    76: 4,  # pad
+                },
+            )
+
+            r = s.extendedcopy5(
+                cscd_descriptor_list=[
+                    {
+                        "descriptor_type_code": "Identification Descriptor CSCD descriptor",
+                        "peripheral_device_type": 0x05,
+                        "cscd_descriptor_parameters": {
+                            "association": ASSOCIATION.ASSOCIATED_WITH_LUN,
+                            "code_set": CODE_SET.BINARY,
+                            "designator_type": DESIGNATOR.NAA,
+                            "designator": {
+                                "naa": NAA.IEEE_REGISTERED_EXTENDED,
+                                "ieee_company_id": 0x589CFC,
+                                "vendor_specific_identifier": 0x00000C44,
+                                "vendor_specific_identifier_extension": 0xC482CC288FBC0D75,
+                            },
+                        },
+                        "device_type_specific_parameters": {
+                            "disk_block_length": 512,
+                        },
+                    }
+                ]
+            )
+            self.assertEqual(len(r.dataout), 80)
+            self.assertEqual(scsi_ba_to_int(r.cdb[10:14]), 80)
+            self.check_hex_str(
+                r.dataout.hex(),
+                {
+                    0: 1,
+                    3: 0x20,
+                    16: 0xFF,
+                    43: 32,  # CSCD DESCRIPTOR LIST LENGTH (LSB)
+                    48: 0xE4,  # Identification Descriptor CSCD descriptor
+                    48 + 1: 0x05,  # Peripheral Device Type
+                    48 + 4: 0x01,  # CODE_SET.BINARY: 0x01
+                    # ASSOCIATION.ASSOCIATED_WITH_LUN: 0x00, DESIGNATOR.NAA: 0x03
+                    48 + 5: 0x03,
+                    # See 7.7.6.6.5 NAA IEEE Registered Extended designator format: 16 bytes
+                    48 + 7: 0x10,
+                    # NAA: 58 9C FC | 00 00 0C 44 | C4 82 CC 28 8F BC 0D 75
+                    # NAA:  5 89 CF C|0 00 00 0C 44 | C4 82 CC 28 8F BC 0D 75
+                    # NAA.IEEE_REGISTERED_EXTENDED: 6, first nibble of ieee_company_id: 5
+                    48 + 8: 0x65,
+                    48 + 9: 0x89,
+                    48 + 10: 0xCF,
+                    48 + 11: 0xC0,
+                    48 + 12: 0x00,
+                    48 + 13: 0x00,
+                    48 + 14: 0x0C,
+                    48 + 15: 0x44,
+                    48 + 16: 0xC4,
+                    48 + 17: 0x82,
+                    48 + 18: 0xCC,
+                    48 + 19: 0x28,
+                    48 + 20: 0x8F,
+                    48 + 21: 0xBC,
+                    48 + 22: 0x0D,
+                    48 + 23: 0x75,
+                    78: 2,  # disk block length (512 == 0x200)
+                },
+            )
+
+            r = s.extendedcopy5(
+                cscd_descriptor_list=[
+                    {
+                        "descriptor_type_code": "Identification Descriptor CSCD descriptor",
+                        "peripheral_device_type": "Stream or Tape",
+                        "cscd_descriptor_parameters": {
+                            "association": ASSOCIATION.ASSOCIATED_WITH_LUN,
+                            "code_set": CODE_SET.ASCII,
+                            "designator_type": DESIGNATOR.T10_VENDOR_ID,
+                            "designator": {
+                                "t10_vendor_id": "TrueNAS ".encode("ascii"),
+                                "vendor_specific_id": "test123".encode("ascii"),
+                            },
+                        },
+                        "device_type_specific_parameters": {
+                            "pad": 1,
+                            "fixed": 1,
+                            "stream_block_length": 1024,
+                        },
+                    }
+                ]
+            )
+            self.assertEqual(len(r.dataout), 80)
+            self.assertEqual(scsi_ba_to_int(r.cdb[10:14]), 80)
+            self.check_hex_str(
+                r.dataout.hex(),
+                {
+                    0: 1,
+                    3: 0x20,
+                    16: 0xFF,
+                    43: 32,
+                    48: 0xE4,  # Identification Descriptor CSCD descriptor
+                    48 + 1: 0x01,  # Peripheral Device Type
+                    48 + 4: 0x02,  # CODE_SET.ASCII: 0x02
+                    # ASSOCIATION.ASSOCIATED_WITH_LUN: 0x00, DESIGNATOR.T10_VENDOR_ID: 0x01
+                    48 + 5: 0x01,
+                    48 + 7: 0x0F,  # len("TrueNAS " + "test123") == 15
+                    # See 7.7.6.4 T10 vendor ID based designator format
+                    48 + 8: ord("T"),
+                    48 + 9: ord("r"),
+                    48 + 10: ord("u"),
+                    48 + 11: ord("e"),
+                    48 + 12: ord("N"),
+                    48 + 13: ord("A"),
+                    48 + 14: ord("S"),
+                    48 + 15: ord(" "),
+                    48 + 16: ord("t"),
+                    48 + 17: ord("e"),
+                    48 + 18: ord("s"),
+                    48 + 19: ord("t"),
+                    48 + 20: ord("1"),
+                    48 + 21: ord("2"),
+                    48 + 22: ord("3"),
+                    48 + 28: 5,  # pad & fixed, see 6.6.5.4
+                    48 + 30: 4,  # stream block length (1024 == 0x400)
+                },
+            )
+
+            # INLINE DATA
+            r = s.extendedcopy5(
+                segment_descriptor_list=[
+                    {
+                        "descriptor_type_code": "Copy from block device to block device",
+                        "dc": 1,
+                        "source_cscd_descriptor_id": 1,
+                        "destination_cscd_descriptor_id": 2,
+                        "block_device_number_of_blocks": 1024,
+                        "source_block_device_logical_block_address": 2048,
+                        "destination_block_device_logical_block_address": 4096,
+                    }
+                ],
+                inline_data=bytearray.fromhex("deadbeef"),
+            )
+            # length 48 + 28 + 4
+            self.assertEqual(len(r.dataout), 80)
+            self.assertEqual(scsi_ba_to_int(r.cdb[10:14]), 80)
+            self.check_hex_str(
+                r.dataout.hex(),
+                {
+                    0: 1,
+                    3: 0x20,
+                    16: 0xFF,
+                    # SEGMENT DESCRIPTOR LIST LENGTH
+                    45: 28,
+                    # INLINE DATA LENGTH
+                    47: 4,
+                    # DESCRIPTOR TYPE CODE: 0x02
+                    48 + 0: 0x02,
+                    # DC: 1
+                    48 + 1: 0x02,
+                    # DESCRIPTOR LENGTH (LSB): 24
+                    48 + 3: 0x18,
+                    # SOURCE CSCD DESCRIPTOR ID (LSB): 1
+                    48 + 5: 1,
+                    # DESTINATION CSCD DESCRIPTOR ID (LSB): 2
+                    48 + 7: 2,
+                    # BLOCK DEVICE NUMBER OF BLOCKS (MSB) 0x04 (1024 == 0x400)
+                    48 + 10: 0x04,
+                    # SOURCE BLOCK DEVICE LOGICAL BLOCK ADDRESS: (2048 == 0x800)
+                    48 + 18: 0x08,
+                    # DESTINATION BLOCK DEVICE LOGICAL BLOCK: (4096 = 0x1000)
+                    48 + 26: 0x10,
+                    # INLINE DATA
+                    48 + 28 + 0: 0xDE,
+                    48 + 28 + 1: 0xAD,
+                    48 + 28 + 2: 0xBE,
+                    48 + 28 + 3: 0xEF,
+                },
+            )


### PR DESCRIPTION
Add initial (incomplete) EXTENDED COPY support for both the SPC-3/SPC-4 variant and the SPC-5 variant.  These variants have some common aspects, but are not compatible and include nomenclature changes.

Reuse (and fix a minor bug in) `Inquiry.marshall_designator`.

----
Still waiting for the [upstream PR](https://github.com/python-scsi/python-scsi/pull/131) to land.