### PR TITLE
Fix iscsi enum use for modern cython

### DIFF
--- a/pyscsi/pyiscsi/iscsi_device.py
+++ b/pyscsi/pyiscsi/iscsi_device.py
@@ -74,8 +74,10 @@ class ISCSIDevice(metaclass=ExMETA):
             self._iscsi = iscsi.Context(device)
         self._iscsi_url = iscsi.URL(self._iscsi, self._file_name)
         self._iscsi.set_targetname(self._iscsi_url.target)
-        self._iscsi.set_session_type(iscsi.ISCSI_SESSION_NORMAL)
-        self._iscsi.set_header_digest(iscsi.ISCSI_HEADER_DIGEST_NONE_CRC32C)
+        self._iscsi.set_session_type(iscsi.iscsi_session_type.ISCSI_SESSION_NORMAL)
+        self._iscsi.set_header_digest(
+            iscsi.iscsi_header_digest.ISCSI_HEADER_DIGEST_NONE_CRC32C
+        )
         self._iscsi.connect(self._iscsi_url.portal, self._iscsi_url.lun)
 
     def close(self):
@@ -86,13 +88,13 @@ class ISCSIDevice(metaclass=ExMETA):
         execute a scsi command
         :param cmd: a scsi command
         """
-        dir = iscsi.SCSI_XFER_NONE
+        dir = iscsi.scsi_xfer_dir.SCSI_XFER_NONE
         xferlen = 0
         if len(cmd.datain):
-            dir = iscsi.SCSI_XFER_READ
+            dir = iscsi.scsi_xfer_dir.SCSI_XFER_READ
             xferlen = len(cmd.datain)
         if len(cmd.dataout):
-            dir = iscsi.SCSI_XFER_WRITE
+            dir = iscsi.scsi_xfer_dir.SCSI_XFER_WRITE
             xferlen = len(cmd.dataout)
         task = iscsi.Task(cmd.cdb, dir, xferlen)
         self._iscsi.command(self._iscsi_url.lun, task, cmd.dataout, cmd.datain)


### PR DESCRIPTION
Modern `cython` changes how `cpdef enum`s are exposed.  Update the tests so that they will work with **both** old and new cython.

Given
```
    cpdef enum iscsi_session_type:
        ISCSI_SESSION_DISCOVERY
        ISCSI_SESSION_NORMAL
```
We used to be able to _**either**_ use `iscsi.ISCSI_SESSION_NORMAL` or `iscsi.iscsi_session_type.ISCSI_SESSION_NORMAL`.  With modern cython, only the latter works.

From https://cython.readthedocs.io/en/latest/src/userguide/language_basics.html#structs-unions-enums

> Up to Cython version 3.0.x, this used to copy all item names into the global module namespace, so that they were available both as attributes of the Python enum type (CheseState above) and as global constants. This was changed in Cython 3.1 to distinguish between anonymous cpdef enums, which only create global Python constants for their items, and named cpdef enums, where the items live only in the namespace of the enum type and do not create global Python constants.

Verified the breakage and fix **in a venv** on Debian Trixie nightly, and on Bookworm.

The https://pypi.org/project/Cython/ shows
- 3.1.0 (2025-05-08)